### PR TITLE
Support oci_path to distinquish charts from docker images in OCI

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -35,8 +35,11 @@ inputs:
   oci_password:
     description: The OCI user's password
     required: true
+  oci_path:
+    description: "Subpath for the chart in oci. (eg. 'oci://${oci_registry}/${oci_path}' instead of the default 'oci://${oci_registry}/')"
+    required: false
   github_token:
-    description: Github Actions token must be provided to manage release creation and update
+    description: "Github Actions token must be provided to manage release creation and update"
     required: true
   install_dir:
     description: "Helm installation directory"
@@ -84,6 +87,10 @@ runs:
 
         if [[ -n "${{ inputs.oci_username }}" ]]; then
           args+=(--oci-username "${{ inputs.oci_username }}")
+        fi
+
+        if [[ -n "${{ inputs.oci_path }}" ]]; then
+          args+=(--oci-path "${{ inputs.oci_path }}")
         fi
 
         if [[ -n "${{ inputs.install_dir }}" ]]; then

--- a/cr.sh
+++ b/cr.sh
@@ -34,6 +34,7 @@ Usage: $(basename "$0") <options>
     -d, --charts-dir              The charts directory (default either: helm, chart or charts)
     -u, --oci-username            The username used to login to the OCI registry
     -r, --oci-registry            The OCI registry
+    -n, --oci-name                Specifies the name of the package in the OCI registry (default is name from Chart.yml)
     -t, --tag-name-pattern        Specifies GitHub repository release naming pattern (ex. '{chartName}-chart')
         --install-dir             Specifies custom install dir
         --skip-helm-install       Skip helm installation (default: false)
@@ -59,6 +60,7 @@ main() {
   local skip_dependencies=false
   local skip_existing=true
   local mark_as_latest=true
+  local oci_name=
   local tag_name_pattern=
   local repo_root=
 
@@ -90,7 +92,11 @@ main() {
       local desc name version info=()
       readarray -t info <<<"$(chart_info "$chart")"
       desc="${info[0]}"
-      name="${info[1]}"
+      if [[ -n ${oci_pattern} ]]; then
+        name="${oci_pattern}"
+      else
+        name="${info[1]}"
+      fi
       version="${info[2]}"
 
       package_chart "$chart"
@@ -187,7 +193,13 @@ parse_command_line() {
         shift
       fi
       ;;
-    -t | --tag-name-pattern)
+      -n | --oci-name)
+      if [[ -n "${2:-}" ]]; then
+        oci_name="$2"
+        shift
+      fi
+      ;;
+      -t | --tag-name-pattern)
       if [[ -n "${2:-}" ]]; then
         tag_name_pattern="$2"
         shift


### PR DESCRIPTION
for example we want the main project foo docker image to be called "foo" and the associated chart to be called "chart/foo" in the registry.