### PR TITLE
Support skipping oci login through command line flag

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,6 +23,7 @@ A GitHub action for single chart or multi-chart repositories that performs push 
 - `skip_helm_install`: Skip helm installation (default: false)
 - `skip_dependencies`: Skip dependencies update from "Chart.yaml" to dir "charts/" before packaging (default: false)
 - `skip_existing`: Skip the chart push if the GithHub release exists
+- `skip_oci_login`: Skip the OCI login step (rely on existing credentials)
 - `mark_as_latest`: When you set this to `false`, it will mark the created GitHub release not as 'latest'.
 
 ### Outputs

--- a/action.yml
+++ b/action.yml
@@ -50,6 +50,9 @@ inputs:
   skip_upload:
     description: "Skip the chart package upload if the GithHub release exists"
     required: false
+  skip_oci_login:
+    description: "Skip the OCI login step (rely on existing credentials)"
+    required: false
   mark_as_latest:
     description: "Mark the created GitHub release as 'latest'"
     required: false
@@ -104,6 +107,10 @@ runs:
 
         if [[ -n "${{ inputs.skip_existing }}" ]]; then
             args+=(--skip-existing "${{ inputs.skip_existing }}")
+        fi
+
+        if [[ -n "${{ inputs.skip_oci_login }}" ]]; then
+            args+=(--skip-oci-login "${{ inputs.skip_oci_login }}")
         fi
 
         if [[ -n "${{ inputs.mark_as_latest }}" ]]; then

--- a/cr.sh
+++ b/cr.sh
@@ -40,6 +40,7 @@ Usage: $(basename "$0") <options>
         --skip-helm-install       Skip helm installation (default: false)
         --skip-dependencies       Skip dependencies update from "Chart.yaml" to dir "charts/" before packaging (default: false)
         --skip-exisiting          Skip the chart push if the GithHub release exists
+        --skip-oci-login          Skip the OCI registry login (default: false)
     -l, --mark-as-latest          Mark the created GitHub release as 'latest' (default: true)
 EOF
 }
@@ -59,6 +60,7 @@ main() {
   local skip_helm_install=false
   local skip_dependencies=false
   local skip_existing=true
+  local skip_oci_login=false
   local mark_as_latest=true
   local tag_name_pattern=
   local repo_root=
@@ -66,7 +68,9 @@ main() {
   parse_command_line "$@"
 
   : "${GITHUB_TOKEN:?Environment variable GITHUB_TOKEN must be set}"
-  : "${OCI_PASSWORD:?Environment variable OCI_PASSWORD must be set}"
+  if ( ! $skip_oci_login ) then
+    : "${OCI_PASSWORD:?Environment variable OCI_PASSWORD must be set unless you skip oci login.}"
+  fi
 
   (! $dry_run) || echo "===> DRY-RUN: TRUE"
 
@@ -182,6 +186,12 @@ parse_command_line() {
         shift
       fi
       ;;
+    --skip-oci-login)
+      if [ "${2}" == "true" ]; then
+        skip_oci_login=true
+        shift
+      fi
+      ;;
     -l | --mark-as-latest)
       if [[ -n "${2:-}" ]]; then
         mark_as_latest="$2"
@@ -202,10 +212,12 @@ parse_command_line() {
     shift
   done
 
-  if [[ -z "$oci_username" ]]; then
-    echo "ERROR: '-u|--oci-username' is required." >&2
-    show_help
-    exit 1
+  if ( ! $skip_oci_login ) then
+    if [[ -z "$oci_username"  ]]; then
+      echo "ERROR: '-u|--oci-username' is required unless you skip oci login." >&2
+      show_help
+      exit 1
+    fi
   fi
 
   if [[ -z "$oci_registry" ]]; then
@@ -365,6 +377,10 @@ release_chart() {
 }
 
 helm_login() {
+  if ( $skip_oci_login ) then
+    echo "Skipping helm login. Using existing credentials..."
+    return
+  fi
   # Get the cleared host url
   oci_registry="${oci_registry#oci://}"
   oci_host="${oci_registry%%/*}"


### PR DESCRIPTION
Added the skip-oci-login command line flag. When set to true it will no longer requires oci user and password to be specified and simply skip the helm login. This supports cases where you already logged into the OCI repository in a previous step.