### PR TITLE
Allow skipping GH release upload

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,6 +25,7 @@ A GitHub action for single chart or multi-chart repositories that performs push 
 - `skip_existing`: Skip the chart push if the GithHub release exists
 - `skip_oci_login`: Skip the OCI login step (rely on existing credentials)
 - `mark_as_latest`: When you set this to `false`, it will mark the created GitHub release not as 'latest'.
+- `skip_gh_release`: Skip the GitHub release creation
 
 ### Outputs
 

--- a/action.yml
+++ b/action.yml
@@ -60,6 +60,9 @@ inputs:
   tag_name_pattern:
     description: "Specifies GitHub repository release naming pattern (ex. '{chartName}-chart')"
     required: false
+  skip_gh_release:
+    description: "Skip the GitHub release creation"
+    required: false
 outputs:
   changed_charts:
     description: "A comma-separated list of charts that were released on this run. Will be an empty string if no updates were detected, will be unset if `--skip_packaging` is used: in the latter case your custom packaging step is responsible for setting its own outputs if you need them."
@@ -119,6 +122,10 @@ runs:
 
         if [[ -n "${{ inputs.tag_name_pattern }}" ]]; then
             args+=(--tag-name-pattern "${{ inputs.tag_name_pattern }}")
+        fi
+        
+        if [[ -n "${{ inputs.skip_gh_release }}" ]]; then
+            args+=(--skip-gh-release "${{ inputs.skip_gh_release }}")
         fi
 
         export GITHUB_TOKEN="${{ inputs.github_token }}"


### PR DESCRIPTION
Add a new configuraiton value `skip_gh_release` and a new flag `--skip-gh-release` which should skip the creation and upload of release artifacts to Github.