### PR TITLE
Fix skip_existing option not existing warning

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -47,6 +47,9 @@ inputs:
   skip_dependencies:
     description: "Skip dependency update during packaging"
     required: false
+  skip_existing:
+    description: "Skip package upload if release exists"
+    required: false
   skip_upload:
     description: "Skip the chart package upload if the GithHub release exists"
     required: false


### PR DESCRIPTION
There is still a warning that in the that the skip_existing input does not exist for the action, even though it is clearly supported.
This should fix that.