### PR TITLE
chore: Clean up after oci_path removal

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -88,10 +88,6 @@ runs:
           args+=(--oci-registry "${{ inputs.oci_registry }}")
         fi
 
-        if [[ -n "${{ inputs.oci_path }}" ]]; then
-          args+=(--oci-path "${{ inputs.oci_path }}")
-        fi
-
         if [[ -n "${{ inputs.oci_username }}" ]]; then
           args+=(--oci-username "${{ inputs.oci_username }}")
         fi

--- a/cr.sh
+++ b/cr.sh
@@ -34,7 +34,6 @@ Usage: $(basename "$0") <options>
     -d, --charts-dir              The charts directory (default either: helm, chart or charts)
     -u, --oci-username            The username used to login to the OCI registry
     -r, --oci-registry            The OCI registry
-    -p, --oci-path                The OCI path to construct full path as {{oci-registry}}/{{oci-path}}
     -t, --tag-name-pattern        Specifies GitHub repository release naming pattern (ex. '{chartName}-chart')
         --install-dir             Specifies custom install dir
         --skip-helm-install       Skip helm installation (default: false)


### PR DESCRIPTION
The oci_path input support was removed in #4


